### PR TITLE
Fix null handling in DeviceTree

### DIFF
--- a/UsbChecker.cs
+++ b/UsbChecker.cs
@@ -37,7 +37,7 @@ namespace UsbChecker
         private DeviceNode _rootNode;
 
         // flat collection of all devices found
-        private List< DeviceNode > _deviceNodes;
+        private List< DeviceNode > _deviceNodes = new List<DeviceNode>();
 
         public DeviceNode RootNode
         {
@@ -75,7 +75,7 @@ namespace UsbChecker
         {
             if (disposing)
             {
-                this._deviceNodes.Clear();
+                this._deviceNodes?.Clear();
             }
 
             this.DisconnectFromMachine();


### PR DESCRIPTION
## Summary
- prevent `DeviceTree` from creating a null device list
- guard against null list in `Dispose`

## Testing
- `dotnet test` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684628dcb71083228598f4e00b526784